### PR TITLE
Add vybing.dev - practitioner-facing benchmark directory for code LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4848,6 +4848,7 @@ For each task, the first column contains non-neural methods (e.g. n-gram, TF-IDF
 8. "Large Language Models are Qualified Benchmark Builders: Rebuilding Pre-Training Datasets for Advancing Code Intelligence Tasks" [2025-04] [[paper](https://arxiv.org/abs/2504.19444)]
 
 ### 8.2 Benchmarks
+- [vybing.dev](https://vybing.dev) - AI dev tool directory with benchmark-backed rankings; covers coding assistants, LLM APIs, agents, and dev tooling.
 
 #### Integrated Benchmarks
 


### PR DESCRIPTION
## What is vybing.dev

[vybing.dev](https://vybing.dev) is an AI developer tools directory with benchmark-backed rankings. It covers coding assistants, LLM APIs, agents, and dev tooling, with a transparent ranking methodology at [vybing.dev/methodology](https://vybing.dev/methodology). Rankings are not influenced by affiliates or paid placements.

## Why it fits this list

Awesome-Code-LLM curates research and resources on language models for code. vybing.dev provides the practitioner-facing counterpart: real-world benchmark rankings of the coding tools and LLMs covered in this list, with transparent scoring methodology.

## Entry added

`- [vybing.dev](https://vybing.dev) - AI dev tool directory with benchmark-backed rankings; covers coding assistants, LLM APIs, agents, and dev tooling.`