### PR TITLE
Add FIM-Midtraining (function-aware FIM mid-training for coding agent foundation models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,6 +1282,7 @@ These models apply Instruction Fine-Tuning techniques to enhance the capacities 
 121. **KAT-Coder-V2**: "KAT-Coder-V2 Technical Report" [2026-03] [[paper](https://arxiv.org/abs/2603.27703)]
 
 122. **SWE Atlas**: "SWE Atlas: Benchmarking Coding Agents Beyond Issue Resolution" [2026-05] [[paper](https://arxiv.org/abs/2605.08366)]
+123. **FIM-Midtraining**: "Function-Aware Fill-in-the-Middle as Mid-Training for Coding Agent Foundation Models" [2026-07] [[paper](https://arxiv.org/abs/2607.12463)] [[repo](https://github.com/TIGER-AI-Lab/FIM-Midtraining)] [[data & models](https://huggingface.co/collections/TIGER-Lab/fim-midtraining)]
 
 ### 3.4 Interactive Coding
 


### PR DESCRIPTION
Adds **FIM-Midtraining** to `### 3.3 Code Agents`, next to the existing mid-training entries (daVinci-Dev, HE-SNR).

Function-Aware Fill-in-the-Middle as Mid-Training (arXiv:2607.12463, TMLR-line work) treats a coding agent's act→observe→continue loop as isomorphic to a function call site: mask PDG-selected functions, mid-train on rationale-first recovery, then run standard agentic post-training unchanged. Ships FIM-{7,8,14}B checkpoints + a 400K / 2.6B-token corpus; improves SWE-Bench-Verified/Lite across Qwen2.5-Coder and Qwen3 bases.

- Paper: https://arxiv.org/abs/2607.12463
- Code: https://github.com/TIGER-AI-Lab/FIM-Midtraining
- Models + data: https://huggingface.co/collections/TIGER-Lab/fim-midtraining

Numbered per the section's format. Disclosure: I'm a co-author. Thanks for maintaining this list!